### PR TITLE
25 uiux menu que apresente os controles do jogo

### DIFF
--- a/ciclo_infinito/levels/cheese_hall/cheese_hall.tscn
+++ b/ciclo_infinito/levels/cheese_hall/cheese_hall.tscn
@@ -295,7 +295,6 @@ sources/1 = SubResource("TileSetAtlasSource_qy7ad")
 
 [node name="TerrainManager2" type="Node2D" unique_id=481706482]
 position = Vector2(-11, -21)
-scale = Vector2(1.4, 1.4)
 script = ExtResource("1_dw1uh")
 metadata/_edit_horizontal_guides_ = [724.0, 5.0, -40.0]
 metadata/_edit_vertical_guides_ = [69.0, 1194.0, 1072.0]

--- a/ciclo_infinito/levels/cheese_hall/cheese_hall.tscn
+++ b/ciclo_infinito/levels/cheese_hall/cheese_hall.tscn
@@ -390,10 +390,15 @@ tile_set = SubResource("TileSet_vft3r")
 position = Vector2(152.857, 284.286)
 
 [node name="pause" parent="player" unique_id=2143532255 instance=ExtResource("13_v1y88")]
-offset_left = -170.13
-offset_top = -82.4678
-offset_right = 469.87
-offset_bottom = 277.532
+anchors_preset = 0
+anchor_right = 0.0
+anchor_bottom = 0.0
+offset_left = -164.28557
+offset_top = -86.3639
+offset_right = 475.71442
+offset_bottom = 273.6361
+grow_horizontal = 1
+grow_vertical = 1
 scale = Vector2(0.521822, 0.503862)
 
 [node name="ParedeUerj" type="TileMapLayer" parent="." unique_id=1524752549]

--- a/ciclo_infinito/levels/cheese_hall/cheese_hall.tscn
+++ b/ciclo_infinito/levels/cheese_hall/cheese_hall.tscn
@@ -295,6 +295,7 @@ sources/1 = SubResource("TileSetAtlasSource_qy7ad")
 
 [node name="TerrainManager2" type="Node2D" unique_id=481706482]
 position = Vector2(-11, -21)
+scale = Vector2(1.4, 1.4)
 script = ExtResource("1_dw1uh")
 metadata/_edit_horizontal_guides_ = [724.0, 5.0, -40.0]
 metadata/_edit_vertical_guides_ = [69.0, 1194.0, 1072.0]

--- a/ciclo_infinito/levels/fifth_floor/fifth_floor.tscn
+++ b/ciclo_infinito/levels/fifth_floor/fifth_floor.tscn
@@ -20,7 +20,6 @@
 size = Vector2(154.643, 5.35712)
 
 [node name="QuintoAndar" type="Node2D" unique_id=1838089692]
-scale = Vector2(1.4, 1.4)
 script = ExtResource("1_u87vb")
 
 [node name="TerrainManager" parent="." unique_id=468786021 instance=ExtResource("8_wow6u")]

--- a/ciclo_infinito/levels/fifth_floor/fifth_floor.tscn
+++ b/ciclo_infinito/levels/fifth_floor/fifth_floor.tscn
@@ -20,6 +20,7 @@
 size = Vector2(154.643, 5.35712)
 
 [node name="QuintoAndar" type="Node2D" unique_id=1838089692]
+scale = Vector2(1.4, 1.4)
 script = ExtResource("1_u87vb")
 
 [node name="TerrainManager" parent="." unique_id=468786021 instance=ExtResource("8_wow6u")]
@@ -47,15 +48,15 @@ text = "Pedro"
 position = Vector2(574, -278)
 
 [node name="pause" parent="player" unique_id=318316374 instance=ExtResource("12_2g3x2")]
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -273.0
-offset_top = -154.0
-offset_right = 817.0
-offset_bottom = 460.0
+anchors_preset = 0
+anchor_right = 0.0
+anchor_bottom = 0.0
+offset_left = -163.3766
+offset_top = -75.19482
+offset_right = 476.6234
+offset_bottom = 284.80518
+grow_horizontal = 1
+grow_vertical = 1
 scale = Vector2(0.5, 0.5)
 
 [node name="enemies" type="Label" parent="player" unique_id=574180986]

--- a/ciclo_infinito/menus/controls/menu_controles.gd
+++ b/ciclo_infinito/menus/controls/menu_controles.gd
@@ -1,17 +1,5 @@
 extends Control
 
-
-
-# Called when the node enters the scene tree for the first time.
-func _ready() -> void:
-	pass # Replace with function body.
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta: float) -> void:
-	pass
-
-
 func _on_voltar_pressed() -> void:
 	if get_parent() != get_tree().root:
 		var pause_menu = get_parent().get_node_or_null("MarginContainer")

--- a/ciclo_infinito/menus/controls/menu_controles.gd
+++ b/ciclo_infinito/menus/controls/menu_controles.gd
@@ -1,0 +1,23 @@
+extends Control
+
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass
+
+
+func _on_voltar_pressed() -> void:
+	if get_parent() != get_tree().root:
+		var pause_menu = get_parent().get_node_or_null("MarginContainer")
+		if pause_menu:
+			pause_menu.show()
+		queue_free()
+	else:
+		get_tree().change_scene_to_file("res://menus/main/main_menu.tscn")
+	pass

--- a/ciclo_infinito/menus/controls/menu_controles.gd.uid
+++ b/ciclo_infinito/menus/controls/menu_controles.gd.uid
@@ -1,0 +1,1 @@
+uid://bubtax7ha8ijd

--- a/ciclo_infinito/menus/controls/menu_controles.tscn
+++ b/ciclo_infinito/menus/controls/menu_controles.tscn
@@ -1,0 +1,153 @@
+[gd_scene format=3 uid="uid://jgxnlfi33ok0"]
+
+[ext_resource type="Script" uid="uid://bubtax7ha8ijd" path="res://menus/controls/menu_controles.gd" id="1_hnxwp"]
+[ext_resource type="Texture2D" uid="uid://n6opr2ssjnv5" path="res://assets/art/menus/main_menu/university_front_view.png" id="2_opgxd"]
+[ext_resource type="FontFile" uid="uid://dboxkasdapd73" path="res://assets/fonts/BoldPixels.ttf" id="3_oqebd"]
+
+[node name="MenuControles" type="Control" unique_id=388669314]
+process_mode = 3
+z_index = 10
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_hnxwp")
+metadata/_edit_vertical_guides_ = [133.0, 617.0]
+metadata/_edit_horizontal_guides_ = [405.0, 326.0, 244.0, 156.0, 67.0]
+
+[node name="TextureRect" type="TextureRect" parent="." unique_id=1170788630]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -288.0
+offset_top = -242.0
+offset_right = 288.0
+offset_bottom = 242.0
+grow_horizontal = 2
+grow_vertical = 2
+texture = ExtResource("2_opgxd")
+expand_mode = 1
+
+[node name="ColorRect" type="ColorRect" parent="TextureRect" unique_id=1374080318]
+layout_mode = 0
+offset_right = 1536.0
+offset_bottom = 1024.0
+color = Color(0.4117647, 0.4117647, 0.4117647, 0.5019608)
+
+[node name="VBoxContainer" type="VBoxContainer" parent="TextureRect/ColorRect" unique_id=898731452]
+layout_mode = 0
+offset_left = 735.0
+offset_top = 300.0
+offset_right = 904.0
+offset_bottom = 575.0
+
+[node name="A" type="Label" parent="TextureRect/ColorRect/VBoxContainer" unique_id=1405046451]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.94509804, 0.8901961, 1, 1)
+theme_override_fonts/font = ExtResource("3_oqebd")
+theme_override_font_sizes/font_size = 36
+text = "A"
+
+[node name="D" type="Label" parent="TextureRect/ColorRect/VBoxContainer" unique_id=1649616519]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.94509804, 0.8901961, 1, 1)
+theme_override_fonts/font = ExtResource("3_oqebd")
+theme_override_font_sizes/font_size = 36
+text = "D"
+
+[node name="W" type="Label" parent="TextureRect/ColorRect/VBoxContainer" unique_id=192741996]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.94509804, 0.8901961, 1, 1)
+theme_override_fonts/font = ExtResource("3_oqebd")
+theme_override_font_sizes/font_size = 36
+text = "W"
+
+[node name="S" type="Label" parent="TextureRect/ColorRect/VBoxContainer" unique_id=627413529]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.94509804, 0.8901961, 1, 1)
+theme_override_fonts/font = ExtResource("3_oqebd")
+theme_override_font_sizes/font_size = 36
+text = "S"
+
+[node name="Space" type="Label" parent="TextureRect/ColorRect/VBoxContainer" unique_id=1527023623]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.94509804, 0.8901961, 1, 1)
+theme_override_fonts/font = ExtResource("3_oqebd")
+theme_override_font_sizes/font_size = 36
+text = "Space"
+
+[node name="Left_Mouse" type="Label" parent="TextureRect/ColorRect/VBoxContainer" unique_id=6067225]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.94509804, 0.8901961, 1, 1)
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 0)
+theme_override_fonts/font = ExtResource("3_oqebd")
+theme_override_font_sizes/font_size = 36
+text = "Left Mouse"
+
+[node name="VBoxContainer2" type="VBoxContainer" parent="TextureRect/ColorRect" unique_id=1451424201]
+layout_mode = 0
+offset_left = 332.0
+offset_top = 300.0
+offset_right = 501.0
+offset_bottom = 536.0
+
+[node name="Move_left" type="Label" parent="TextureRect/ColorRect/VBoxContainer2" unique_id=1449700252]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.94509804, 0.8901961, 1, 1)
+theme_override_fonts/font = ExtResource("3_oqebd")
+theme_override_font_sizes/font_size = 36
+text = "Move Left"
+
+[node name="Move_Right" type="Label" parent="TextureRect/ColorRect/VBoxContainer2" unique_id=2022711848]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.94509804, 0.8901961, 1, 1)
+theme_override_fonts/font = ExtResource("3_oqebd")
+theme_override_font_sizes/font_size = 36
+text = "Move Right"
+
+[node name="Move_Up" type="Label" parent="TextureRect/ColorRect/VBoxContainer2" unique_id=148752357]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.94509804, 0.8901961, 1, 1)
+theme_override_fonts/font = ExtResource("3_oqebd")
+theme_override_font_sizes/font_size = 36
+text = "Move Up"
+
+[node name="Move_Down" type="Label" parent="TextureRect/ColorRect/VBoxContainer2" unique_id=1397644265]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.94509804, 0.8901961, 1, 1)
+theme_override_fonts/font = ExtResource("3_oqebd")
+theme_override_font_sizes/font_size = 36
+text = "Move Down"
+
+[node name="Dash" type="Label" parent="TextureRect/ColorRect/VBoxContainer2" unique_id=1188692537]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.94509804, 0.8901961, 1, 1)
+theme_override_fonts/font = ExtResource("3_oqebd")
+theme_override_font_sizes/font_size = 36
+text = "Dash"
+
+[node name="Attack" type="Label" parent="TextureRect/ColorRect/VBoxContainer2" unique_id=894154808]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.94509804, 0.8901961, 1, 1)
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 0)
+theme_override_fonts/font = ExtResource("3_oqebd")
+theme_override_font_sizes/font_size = 36
+text = "Attack"
+
+[node name="Voltar" type="Button" parent="." unique_id=2049924230]
+layout_mode = 0
+offset_left = 33.0
+offset_top = 326.0
+offset_right = 168.0
+offset_bottom = 381.0
+theme_override_colors/font_color = Color(0.94509804, 0.8901961, 1, 1)
+theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_oqebd")
+theme_override_font_sizes/font_size = 36
+text = "Voltar"
+
+[connection signal="pressed" from="Voltar" to="." method="_on_voltar_pressed"]

--- a/ciclo_infinito/menus/main/main_menu.gd
+++ b/ciclo_infinito/menus/main/main_menu.gd
@@ -28,3 +28,8 @@ func _on_opções_button_pressed() -> void:
 
 func _on_discordbutton_pressed()->void:
 	OS.shell_open("https://discord.com/channels/1409169018534891644/1412147166658429038")
+
+
+func _on_controles_button_pressed() -> void:
+	get_tree().change_scene_to_file("res://menus/controls/menu_controles.tscn")
+	pass # Replace with function body.

--- a/ciclo_infinito/menus/main/main_menu.tscn
+++ b/ciclo_infinito/menus/main/main_menu.tscn
@@ -83,6 +83,18 @@ theme_override_font_sizes/font_size = 46
 theme_override_styles/hover = SubResource("StyleBoxFlat_85i58")
 text = "Créditos"
 
+[node name="Controles_Button" type="Button" parent="VBoxContainer" unique_id=168128271]
+layout_mode = 2
+size_flags_horizontal = 0
+size_flags_vertical = 4
+theme_override_colors/font_color = Color(0.94509804, 0.8901961, 1, 1)
+theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/font_outline_color = Color(0, 0, 0, 1)
+theme_override_fonts/font = ExtResource("3_cqjrg")
+theme_override_font_sizes/font_size = 46
+text = "Controles
+"
+
 [node name="Sair_Button" type="Button" parent="VBoxContainer" unique_id=747055780]
 layout_mode = 2
 size_flags_horizontal = 0
@@ -109,5 +121,6 @@ stretch_mode = 0
 [connection signal="pressed" from="VBoxContainer/Jogar_Button" to="." method="_on_jogar_button_pressed"]
 [connection signal="pressed" from="VBoxContainer/Opções_Button" to="." method="_on_opções_button_pressed"]
 [connection signal="pressed" from="VBoxContainer/Creditos_button" to="." method="_on_creditos_button_pressed"]
+[connection signal="pressed" from="VBoxContainer/Controles_Button" to="." method="_on_controles_button_pressed"]
 [connection signal="pressed" from="VBoxContainer/Sair_Button" to="." method="_on_sair_button_pressed"]
 [connection signal="pressed" from="discordbutton" to="." method="_on_discordbutton_pressed"]

--- a/ciclo_infinito/menus/options/menu_de_opcoes.gd
+++ b/ciclo_infinito/menus/options/menu_de_opcoes.gd
@@ -36,4 +36,5 @@ func _update_label(db_value: float) -> void:
 
 func _on_voltar_button_pressed() -> void:
 	get_tree().change_scene_to_packed(main_menu)
+	
 	pass

--- a/ciclo_infinito/menus/pause/pause.gd
+++ b/ciclo_infinito/menus/pause/pause.gd
@@ -62,10 +62,7 @@ func _update_volume_label(value: float) -> void:
 	volume_label.text = "Volume: %d%%" % clamp(percent, 0, 100)
 
 
-
-
 func _on_controles_pressed() -> void:
-	print("SINAL RECEBIDO COM SUCESSO!") # Se isso aparecer, o problema acaba aqui.
 	var instancia = cena_controles.instantiate()
 	add_child(instancia)
 	$MarginContainer.hide()

--- a/ciclo_infinito/menus/pause/pause.gd
+++ b/ciclo_infinito/menus/pause/pause.gd
@@ -3,6 +3,8 @@ extends Control
 
 var main_menu = load("uid://downt2rxxaqaf")
 var master_idx: int
+var cena_controles = preload("res://menus/controls/menu_controles.tscn")
+
 
 @onready var resume_button = $MarginContainer/VBoxContainer/MenuPrincipal/resumebutton
 @onready var options_button = $MarginContainer/VBoxContainer/MenuPrincipal/optionsbutton
@@ -58,3 +60,13 @@ func _update_volume_slider()-> void:
 func _update_volume_label(value: float) -> void:
 	var percent = int(value)
 	volume_label.text = "Volume: %d%%" % clamp(percent, 0, 100)
+
+
+
+
+func _on_controles_pressed() -> void:
+	print("SINAL RECEBIDO COM SUCESSO!") # Se isso aparecer, o problema acaba aqui.
+	var instancia = cena_controles.instantiate()
+	add_child(instancia)
+	$MarginContainer.hide()
+	pass # Replace with function body.

--- a/ciclo_infinito/menus/pause/pause.tscn
+++ b/ciclo_infinito/menus/pause/pause.tscn
@@ -55,6 +55,11 @@ text = "Resume"
 layout_mode = 2
 text = "Opções"
 
+[node name="Controles" type="Button" parent="MarginContainer/VBoxContainer/MenuPrincipal" unique_id=456575190]
+layout_mode = 2
+text = "Controles
+"
+
 [node name="quitbutton" type="Button" parent="MarginContainer/VBoxContainer/MenuPrincipal" unique_id=780739351]
 layout_mode = 2
 text = "Voltar ao menu iniciar"
@@ -87,6 +92,7 @@ text = "Voltar"
 
 [connection signal="pressed" from="MarginContainer/VBoxContainer/MenuPrincipal/resumebutton" to="." method="_on_resumebutton_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/MenuPrincipal/optionsbutton" to="." method="_on_optionsbutton_pressed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/MenuPrincipal/Controles" to="." method="_on_controles_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/MenuPrincipal/quitbutton" to="." method="_on_quitbutton_pressed"]
 [connection signal="value_changed" from="MarginContainer/VBoxContainer/MenuOpcoes/HBoxContainer/VolumeSlider" to="." method="_on_volume_changed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/MenuOpcoes/BackButton" to="." method="_on_backbutton_pressed"]


### PR DESCRIPTION
# :notebook_with_decorative_cover: Descrição Geral
>Relacionado a: # (Link da issue/task)

 Foi adicionado um menu  ( sem a possibilidade de mapeamento por input ) com os comandos do jogo já definidos no mapa de entrada do próprio godot.  O menu está funcional dentro do jogo e no main menu, mas para que funcione em sua total plenitude, é necessário padronizar as escalas das cenas. ( Closes #25 )

# :open_file_folder: Alterações de Arquivos
  
>Marque com :heavy_check_mark: ou :x:

[ :heavy_check_mark: ] Lógica (.gd): Scripts alterados/adicionados.

 [ :heavy_check_mark: ] Cenas (.tscn): Mudanças na árvore de nós ou herança.

[ :heavy_check_mark: ] Recursos (.tres / .res): Novos materiais, temas ou configurações.

[ :x: ] Assets: Sprites, áudios ou modelos.

# :gear: Checklist Técnico
[ :heavy_check_mark: ] Estilo de Código: As alterações seguem rigorosamente o Guia de Estilo do Projeto.

[ :heavy_check_mark: ] Sinais e Memória: Garanti que sinais desconectam corretamente ou não criam referências cíclicas que impedem o free().

[ :heavy_check_mark: ] Export Vars: Variáveis @export estão organizadas e com nomes legíveis e descrição para os designers no Inspector.

# :globe_with_meridians: Compatibilidade (Web & Desktop)
[ :heavy_check_mark:] Testado no Editor (Desktop).

[ :x: ] Testado via Web Export (ou verificado se utiliza funções não suportadas em HTML5, como Threads específicas ou shaders complexos).