### PR TITLE
fix(tela cheia): Foi consertada a tela cheia que nao abria

### DIFF
--- a/ciclo_infinito/menus/options/menu_de_opcoes.gd
+++ b/ciclo_infinito/menus/options/menu_de_opcoes.gd
@@ -37,3 +37,11 @@ func _update_label(db_value: float) -> void:
 func _on_voltar_button_pressed() -> void:
 	get_tree().change_scene_to_packed(main_menu)
 	pass
+
+
+func _on_alternar_tela_cheia_pressed() -> void:
+	if DisplayServer.window_get_mode() == DisplayServer.WINDOW_MODE_FULLSCREEN:
+		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
+	else:
+		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
+	pass # Replace with function body.

--- a/ciclo_infinito/menus/options/menu_de_opcoes.tscn
+++ b/ciclo_infinito/menus/options/menu_de_opcoes.tscn
@@ -102,4 +102,5 @@ theme_override_fonts/font = ExtResource("2_c01ij")
 theme_override_font_sizes/font_size = 32
 text = "Voltar"
 
+[connection signal="pressed" from="MarginContainer2/VBoxContainer/Alternar tela cheia" to="." method="_on_alternar_tela_cheia_pressed"]
 [connection signal="pressed" from="MarginContainer2/VBoxContainer/voltar_button" to="." method="_on_voltar_button_pressed"]

--- a/ciclo_infinito/menus/pause/pause.gd
+++ b/ciclo_infinito/menus/pause/pause.gd
@@ -58,3 +58,11 @@ func _update_volume_slider()-> void:
 func _update_volume_label(value: float) -> void:
 	var percent = int(value)
 	volume_label.text = "Volume: %d%%" % clamp(percent, 0, 100)
+
+
+func _on_full_screen_button_pressed() -> void:
+	if DisplayServer.window_get_mode() == DisplayServer.WINDOW_MODE_FULLSCREEN:
+		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_WINDOWED)
+	else:
+		DisplayServer.window_set_mode(DisplayServer.WINDOW_MODE_FULLSCREEN)
+	pass # Replace with function body.

--- a/ciclo_infinito/menus/pause/pause.tscn
+++ b/ciclo_infinito/menus/pause/pause.tscn
@@ -89,4 +89,5 @@ text = "Voltar"
 [connection signal="pressed" from="MarginContainer/VBoxContainer/MenuPrincipal/optionsbutton" to="." method="_on_optionsbutton_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/MenuPrincipal/quitbutton" to="." method="_on_quitbutton_pressed"]
 [connection signal="value_changed" from="MarginContainer/VBoxContainer/MenuOpcoes/HBoxContainer/VolumeSlider" to="." method="_on_volume_changed"]
+[connection signal="pressed" from="MarginContainer/VBoxContainer/MenuOpcoes/FullScreenButton" to="." method="_on_full_screen_button_pressed"]
 [connection signal="pressed" from="MarginContainer/VBoxContainer/MenuOpcoes/BackButton" to="." method="_on_backbutton_pressed"]

--- a/ciclo_infinito/project.godot
+++ b/ciclo_infinito/project.godot
@@ -35,6 +35,7 @@ window/size/viewport_width=960
 window/size/viewport_height=540
 window/size/window_width_override=1280
 window/size/window_height_override=720
+window/subwindows/embed_subwindows=false
 window/stretch/mode="canvas_items"
 
 [input]


### PR DESCRIPTION
# :notebook_with_decorative_cover: Descrição Geral
>Relacionado a: # (Link da issue/task)

Foi consertado o botao de tela cheia que nao abria. Apenas um sinal que não estava conectado. ( Closes #32 )

# :open_file_folder: Alterações de Arquivos
  
>Marque com :heavy_check_mark: ou :x:

[ :heavy_check_mark: ] Lógica (.gd): Scripts alterados/adicionados.

[ :x: ] Cenas (.tscn): Mudanças na árvore de nós ou herança.

[ :x: ] Recursos (.tres / .res): Novos materiais, temas ou configurações.

[ :x: ] Assets: Sprites, áudios ou modelos.

# :gear: Checklist Técnico
[ :heavy_check_mark: ] Estilo de Código: As alterações seguem rigorosamente o Guia de Estilo do Projeto.

[ :heavy_check_mark: ] Sinais e Memória: Garanti que sinais desconectam corretamente ou não criam referências cíclicas que impedem o free().

[ :heavy_check_mark: ] Export Vars: Variáveis @export estão organizadas e com nomes legíveis e descrição para os designers no Inspector.

# :globe_with_meridians: Compatibilidade (Web & Desktop)
[ :heavy_check_mark: ] Testado no Editor (Desktop).

[ :x: ] Testado via Web Export (ou verificado se utiliza funções não suportadas em HTML5, como Threads específicas ou shaders complexos).