### PR TITLE
fix(script) troquei a uid do script da cena victory_screen que aparec…

### DIFF
--- a/ciclo_infinito/menus/end_scenes/victory/victory_screen.gd
+++ b/ciclo_infinito/menus/end_scenes/victory/victory_screen.gd
@@ -18,7 +18,7 @@ func _on_any_button_pressed() -> void:
 
 func _on_jogar_novamente_button_pressed() -> void:
 	await _on_any_button_pressed()
-	EasyTransition.transition_to_scene(load("uid://laif38pcjfq7"),1.5,EasyTransition.TransitionAnim.FADE)
+	EasyTransition.transition_to_scene(load("uid://bgv1wic2ps8oa"),1.5,EasyTransition.TransitionAnim.FADE)
 
 
 func _on_menu_iniciar_button_pressed() -> void:


### PR DESCRIPTION
# :notebook_with_decorative_cover: Descrição Geral
>Closes #102 

Mudei a uid que estava levando a cena errada para a correta

# :open_file_folder: Alterações de Arquivos
  
>Marque com :heavy_check_mark: ou :x:

[ :heavy_check_mark: ] Lógica (.gd): Scripts alterados/adicionados.

[ :x: ] Cenas (.tscn): Mudanças na árvore de nós ou herança.

[ :x: ] Recursos (.tres / .res): Novos materiais, temas ou configurações.

[ :x: ] Assets: Sprites, áudios ou modelos.

# :gear: Checklist Técnico
[ :heavy_check_mark: ] Estilo de Código: As alterações seguem rigorosamente o Guia de Estilo do Projeto.

[ :heavy_check_mark: ] Sinais e Memória: Garanti que sinais desconectam corretamente ou não criam referências cíclicas que impedem o free().

[ :heavy_check_mark: ] Export Vars: Variáveis @export estão organizadas e com nomes legíveis e descrição para os designers no Inspector.

# :globe_with_meridians: Compatibilidade (Web & Desktop)
[ :heavy_check_mark: ] Testado no Editor (Desktop).

[ :x: ] Testado via Web Export (ou verificado se utiliza funções não suportadas em HTML5, como Threads específicas ou shaders complexos).