### PR TITLE
fix(hall barrier) correção das cutscenes aparecendo ao jogar novament…

### DIFF
--- a/ciclo_infinito/levels/cheese_hall/cheese_hall.gd
+++ b/ciclo_infinito/levels/cheese_hall/cheese_hall.gd
@@ -23,6 +23,7 @@ var missoes = [
 
 func _ready():
 	await get_tree().process_frame
+	GameState.fifth_floor_state = GameState.FifthFloorState.FIRST_TALK
 	player.set_camera_limits(left,right,bottom,top)
 	player.camera.zoom = Vector2.ONE*2
 	pause_menu.hide()

--- a/ciclo_infinito/levels/fifth_floor/fifth_floor.gd
+++ b/ciclo_infinito/levels/fifth_floor/fifth_floor.gd
@@ -36,7 +36,6 @@ func _ready():
 	enemies.reparent(player.camera)
 	if pedro:
 		pedro.player_has_talked_with = false
-	GameState.fifth_floor_state = GameState.FifthFloorState.FIRST_TALK
 	_atualizar_texto_missao()
 
 func configurar_label():
@@ -133,4 +132,3 @@ func _on_cutscene_area_body_entered(body: Node2D) -> void:
 	var boss_scene = load("uid://laif38pcjfq7").instantiate()
 	await get_tree().create_timer(1.5).timeout
 	get_tree().change_scene_to_node(boss_scene)
-	

--- a/ciclo_infinito/levels/fifth_floor/fifth_floor.gd
+++ b/ciclo_infinito/levels/fifth_floor/fifth_floor.gd
@@ -31,11 +31,13 @@ func _ready():
 	pause_menu.hide()
 	inimigos_totais = $player/enemies.get_child_count() if $player/enemies else 0
 	configurar_label()
-	_atualizar_texto_missao()
 	conectar_sinais()
 	mission_label.get_parent().reparent(player.camera)
 	enemies.reparent(player.camera)
-
+	if pedro:
+		pedro.player_has_talked_with = false
+	GameState.fifth_floor_state = GameState.FifthFloorState.FIRST_TALK
+	_atualizar_texto_missao()
 
 func configurar_label():
 	mission_label.autowrap_mode=TextServer.AUTOWRAP_WORD

--- a/ciclo_infinito/levels/fifth_floor/fifth_floor.tscn
+++ b/ciclo_infinito/levels/fifth_floor/fifth_floor.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://vxp7ft6bj5g5" path="res://levels/barrier.tscn" id="3_yw1aw"]
 [ext_resource type="PackedScene" uid="uid://djrevjgpeak50" path="res://entities/enemies/golem/golem_white.tscn" id="4_wyqw4"]
 [ext_resource type="PackedScene" uid="uid://dfda1r1btgkpl" path="res://entities/enemies/golem/golem_brown.tscn" id="5_vl0w6"]
-[ext_resource type="Resource" uid="uid://dumym8tg7uleq" path="res://dialogue/pedro.dialogue" id="5_yw1aw"]
+[ext_resource type="Resource" uid="uid://b2lai2jwynri4" path="res://dialogue/pedro.dialogue" id="5_yw1aw"]
 [ext_resource type="PackedScene" uid="uid://deyn0aff4vkxb" path="res://entities/enemies/beholder/beholder_orange.tscn" id="6_3nscd"]
 [ext_resource type="Shader" uid="uid://b4ecm70ug50ju" path="res://resources/shaders/redden.gdshader" id="6_yw1aw"]
 [ext_resource type="PackedScene" uid="uid://c80omegwkn2ei" path="res://entities/enemies/beholder/beholder_white.tscn" id="7_ancri"]


### PR DESCRIPTION
# :notebook_with_decorative_cover: Descrição Geral
>Closes #103 

Correção no jogar novamente de barreiras abrirem ao chegar no quinto andar. 

# :open_file_folder: Alterações de Arquivos
  
>Marque com :heavy_check_mark: ou :x:

[ :heavy_check_mark:  ] Lógica (.gd): Scripts alterados/adicionados.

[ :x: ] Cenas (.tscn): Mudanças na árvore de nós ou herança.

[ :x: ] Recursos (.tres / .res): Novos materiais, temas ou configurações.

[ :x: ] Assets: Sprites, áudios ou modelos.

# :gear: Checklist Técnico
[  :heavy_check_mark: ] Estilo de Código: As alterações seguem rigorosamente o Guia de Estilo do Projeto.

[  :heavy_check_mark: ] Sinais e Memória: Garanti que sinais desconectam corretamente ou não criam referências cíclicas que impedem o free().

[  :heavy_check_mark: ] Export Vars: Variáveis @export estão organizadas e com nomes legíveis e descrição para os designers no Inspector.

# :globe_with_meridians: Compatibilidade (Web & Desktop)
[  :heavy_check_mark: ] Testado no Editor (Desktop).

[ :x: ] Testado via Web Export (ou verificado se utiliza funções não suportadas em HTML5, como Threads específicas ou shaders complexos).