### PR TITLE
fix(Script) alterei o script do player para que o segundo ataque semp…

### DIFF
--- a/ciclo_infinito/entities/player/player.gd
+++ b/ciclo_infinito/entities/player/player.gd
@@ -100,7 +100,9 @@ func _physics_process(delta: float):
 			_dash_state()
 		State.DIALOG:
 			_dialog_state()
-	
+	if combo_buffered and combo_step == 0 and can_start_attack():
+		combo_buffered = false
+		_start_attack1()
 	move_and_slide()
 	_update_attack_area_anchor()
 	update_animation()
@@ -239,6 +241,7 @@ func _open_combo_window() -> void: # Espera a janela de combo e, se houve um ata
 	await get_tree().create_timer(combo_window).timeout
 	combo_window_open = false
 	if combo_step == 1 and combo_buffered:
+		combo_buffered = false
 		_start_attack2()
 
 

--- a/ciclo_infinito/levels/fifth_floor/fifth_floor.tscn
+++ b/ciclo_infinito/levels/fifth_floor/fifth_floor.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://vxp7ft6bj5g5" path="res://levels/barrier.tscn" id="3_yw1aw"]
 [ext_resource type="PackedScene" uid="uid://djrevjgpeak50" path="res://entities/enemies/golem/golem_white.tscn" id="4_wyqw4"]
 [ext_resource type="PackedScene" uid="uid://dfda1r1btgkpl" path="res://entities/enemies/golem/golem_brown.tscn" id="5_vl0w6"]
-[ext_resource type="Resource" uid="uid://dumym8tg7uleq" path="res://dialogue/pedro.dialogue" id="5_yw1aw"]
+[ext_resource type="Resource" uid="uid://b2lai2jwynri4" path="res://dialogue/pedro.dialogue" id="5_yw1aw"]
 [ext_resource type="PackedScene" uid="uid://deyn0aff4vkxb" path="res://entities/enemies/beholder/beholder_orange.tscn" id="6_3nscd"]
 [ext_resource type="Shader" uid="uid://b4ecm70ug50ju" path="res://resources/shaders/redden.gdshader" id="6_yw1aw"]
 [ext_resource type="PackedScene" uid="uid://c80omegwkn2ei" path="res://entities/enemies/beholder/beholder_white.tscn" id="7_ancri"]


### PR DESCRIPTION
# :notebook_with_decorative_cover: Descrição Geral
>Closes #67 

Adição ao script do player verificando os ataques e fazendo esperar 1 combo terminar para começar outro. ajudando a nao bugar visualmente o segundo ataque.

# :open_file_folder: Alterações de Arquivos
  
>Marque com :heavy_check_mark: ou :x:

[  :heavy_check_mark:  ] Lógica (.gd): Scripts alterados/adicionados.

[ :x: ] Cenas (.tscn): Mudanças na árvore de nós ou herança.

[ :x: ] Recursos (.tres / .res): Novos materiais, temas ou configurações.

[ :x: ] Assets: Sprites, áudios ou modelos.

# :gear: Checklist Técnico
[  :heavy_check_mark:  ] Estilo de Código: As alterações seguem rigorosamente o Guia de Estilo do Projeto.

[  :heavy_check_mark:  ] Sinais e Memória: Garanti que sinais desconectam corretamente ou não criam referências cíclicas que impedem o free().

[  :heavy_check_mark:  ] Export Vars: Variáveis @export estão organizadas e com nomes legíveis e descrição para os designers no Inspector.

# :globe_with_meridians: Compatibilidade (Web & Desktop)
[  :heavy_check_mark:  ] Testado no Editor (Desktop).

[ :x: ] Testado via Web Export (ou verificado se utiliza funções não suportadas em HTML5, como Threads específicas ou shaders complexos).